### PR TITLE
Feature: Crawler page logging and summary improvements

### DIFF
--- a/packages/lib/src/cli/ui/summary.ts
+++ b/packages/lib/src/cli/ui/summary.ts
@@ -32,7 +32,7 @@ export function displayCrawlSummary(result: ProcessingResult): void {
 				no_next_button: "no more pages available",
 				all_duplicates: "all items on page were already crawled",
 			};
-			console.log(`   • Stopped: ${reasonMessages[summary.stoppedReason]}`);
+			console.log(`   • Stop reason: ${reasonMessages[summary.stoppedReason]}`);
 		}
 	}
 

--- a/packages/lib/src/crawlers/ArticleListingCrawler.ts
+++ b/packages/lib/src/crawlers/ArticleListingCrawler.ts
@@ -129,6 +129,16 @@ export class ArticleListingCrawler implements Crawler {
 				}
 			}
 
+			// Log page summary
+			const totalItemsOnPage = pageResult.items.length;
+			const newItemsCount = newItems.length;
+			const duplicatesOnPage = totalItemsOnPage - newItemsCount;
+			const filteredOnPage = pageResult.filteredCount;
+
+			console.log(
+				`📄 Page ${pagesProcessed}: found ${totalItemsOnPage + filteredOnPage} items, processed ${newItemsCount} (${duplicatesOnPage} duplicates, ${filteredOnPage} filtered)`,
+			);
+
 			// If all items on this page were duplicates, stop
 			if (pageResult.items.length > 0 && allItemsAreDuplicates) {
 				stoppedReason = "all_duplicates";


### PR DESCRIPTION
- Add real-time page logging during crawls: Shows items found, processed, duplicates, and filtered counts after each page.
Makes it way easier to see what's happening during long crawls instead of 
waiting until the end for feedback.
- Rename "Stopped" to "Stop reason" in crawl summary: More descriptive label that makes it clearer what the field represents.
Small UX improvement for the summary output.