### PR TITLE
feat: better url exclusion

### DIFF
--- a/src/config/sources/eff.ts
+++ b/src/config/sources/eff.ts
@@ -4,7 +4,7 @@ export const effSource: SourceConfig = {
 	id: "eff",
 	name: "Electronic Frontier Foundation",
 	type: "listing",
-	content_url_excludes: ["/event/"],
+	content_url_excludes: ["eff.org/event/", "eff.org/wp/", "eff.org/cases/"],
 	listing: {
 		url: "https://eff.org/updates",
 		pagination: {

--- a/src/crawlers/MetadataTracker.ts
+++ b/src/crawlers/MetadataTracker.ts
@@ -216,10 +216,6 @@ export interface MetadataTracker extends ContentSessionLinker {
 	incrementPagesProcessed(): void;
 	addDuplicatesSkipped(count: number): void;
 	addUrlsExcluded(count: number): void;
-	removeFieldStatsForExcludedUrls(
-		excludedCount: number,
-		excludedItemIndices: number[],
-	): void;
 	addFilteredItems(count: number, reasons: string[]): void;
 	addContentErrors(errors: string[]): void;
 	addFieldExtractionWarnings(warnings: string[]): void;
@@ -349,17 +345,6 @@ export function createMetadataTracker(
 
 		addUrlsExcluded(count: number): void {
 			updateState({ type: MetadataActionType.ADD_URLS_EXCLUDED, count });
-		},
-
-		removeFieldStatsForExcludedUrls(
-			excludedCount: number,
-			excludedItemIndices: number[],
-		): void {
-			updateState({
-				type: MetadataActionType.REMOVE_FIELD_STATS_FOR_EXCLUDED_URLS,
-				excludedCount,
-				excludedItemIndices,
-			});
 		},
 
 		addFilteredItems(count: number, reasons: string[]): void {

--- a/src/crawlers/extractors/ListingPageExtractor.ts
+++ b/src/crawlers/extractors/ListingPageExtractor.ts
@@ -10,6 +10,7 @@ import { parsePublishedDate } from "@/utils/date.js";
 
 export interface ListingExtractionResult {
 	items: CrawledData[];
+	excludedUrls: string[];
 	filteredCount: number;
 	filteredReasons: string[];
 }
@@ -20,6 +21,7 @@ interface ExtractionResult {
 		string,
 		{ success: boolean; value: string | null; error?: string }
 	>;
+	hasExcludedUrl: boolean;
 	hasRequiredFields: boolean;
 	missingRequiredFields: string[];
 	extractionErrors: string[];
@@ -51,144 +53,162 @@ async function extractItemsFromPage(
 		);
 	}
 
-	const extractionResult = await page.evaluate((itemsConfig) => {
-		function extractFieldValue(
-			element: Element | null,
-			fieldConfig: {
-				selector: string;
-				attribute: string;
-				exclude_selectors?: string[];
-				optional?: boolean;
-			},
-		): string | null {
-			if (!element) return null;
-
-			if (fieldConfig.attribute === "text") {
-				return extractTextWithExclusions(
-					element,
-					fieldConfig.exclude_selectors,
-				);
-			} else if (
-				fieldConfig.attribute === "href" ||
-				fieldConfig.attribute === "src"
-			) {
-				const urlValue = element.getAttribute(fieldConfig.attribute);
-				return resolveUrlAttribute(urlValue, window.location.href);
-			} else {
-				return element.getAttribute(fieldConfig.attribute);
-			}
-		}
-
-		function resolveUrlAttribute(
-			urlValue: string | null,
-			baseUrl: string,
-		): string | null {
-			if (!urlValue) return null;
-
-			try {
-				return new URL(urlValue, baseUrl).href;
-			} catch {
-				return urlValue;
-			}
-		}
-
-		function extractTextWithExclusions(
-			element: Element,
-			excludeSelectors?: string[],
-		): string | null {
-			if (excludeSelectors && excludeSelectors.length > 0) {
-				const cloned = element.cloneNode(true) as Element;
-				for (const selector of excludeSelectors) {
-					const excludedElements = cloned.querySelectorAll(selector);
-					for (const excludedElement of excludedElements) {
-						excludedElement.remove();
-					}
-				}
-				return cloned.textContent?.trim().replace(/\s+/g, " ") || null;
-			} else {
-				return element.textContent?.trim().replace(/\s+/g, " ") || null;
-			}
-		}
-
-		const containers = document.querySelectorAll(
-			itemsConfig.container_selector,
-		);
-		const results: ExtractionResult[] = [];
-
-		containers.forEach((container) => {
-			const item: Record<string, string | null> = {};
-			const fieldResults: Record<
-				string,
-				{ success: boolean; value: string | null; error?: string }
-			> = {};
-			let hasRequiredFields = true;
-			const missingRequiredFields: string[] = [];
-			const extractionErrors: string[] = [];
-
-			for (const [fieldName, fieldConfig] of Object.entries(
-				itemsConfig.fields,
-			)) {
-				let success = false;
-				let value: string | null = null;
-				let error: string | undefined;
-
-				const typedFieldConfig = fieldConfig as {
+	const extractionResult = await page.evaluate(
+		(itemsConfig, excludedUrlPaths) => {
+			function extractFieldValue(
+				element: Element | null,
+				fieldConfig: {
 					selector: string;
 					attribute: string;
 					exclude_selectors?: string[];
 					optional?: boolean;
-				};
+				},
+			): string | null {
+				if (!element) return null;
 
-				try {
-					const element = container.querySelector(typedFieldConfig.selector);
-					if (element) {
-						value = extractFieldValue(element, typedFieldConfig);
-					}
-					success = value !== null && value !== "";
-				} catch (err) {
-					error =
-						err instanceof Error
-							? err.message
-							: `Unknown error extracting field ${fieldName}`;
-					extractionErrors.push(
-						`Field '${fieldName}' extraction failed: ${error}`,
+				if (fieldConfig.attribute === "text") {
+					return extractTextWithExclusions(
+						element,
+						fieldConfig.exclude_selectors,
 					);
-				}
-
-				fieldResults[fieldName] = { success, value, error };
-
-				if (success) {
-					item[fieldName] = value;
-				} else if (!typedFieldConfig.optional) {
-					hasRequiredFields = false;
-					missingRequiredFields.push(fieldName);
+				} else if (
+					fieldConfig.attribute === "href" ||
+					fieldConfig.attribute === "src"
+				) {
+					const urlValue = element.getAttribute(fieldConfig.attribute);
+					return resolveUrlAttribute(urlValue, window.location.href);
+				} else {
+					return element.getAttribute(fieldConfig.attribute);
 				}
 			}
 
-			results.push({
-				item,
-				fieldResults,
-				hasRequiredFields,
-				missingRequiredFields,
-				extractionErrors,
-			});
-		});
+			function resolveUrlAttribute(
+				urlValue: string | null,
+				baseUrl: string,
+			): string | null {
+				if (!urlValue) return null;
 
-		return results;
-	}, config.listing.items);
+				try {
+					return new URL(urlValue, baseUrl).href;
+				} catch {
+					return urlValue;
+				}
+			}
+
+			function extractTextWithExclusions(
+				element: Element,
+				excludeSelectors?: string[],
+			): string | null {
+				if (excludeSelectors && excludeSelectors.length > 0) {
+					const cloned = element.cloneNode(true) as Element;
+					for (const selector of excludeSelectors) {
+						const excludedElements = cloned.querySelectorAll(selector);
+						for (const excludedElement of excludedElements) {
+							excludedElement.remove();
+						}
+					}
+					return cloned.textContent?.trim().replace(/\s+/g, " ") || null;
+				} else {
+					return element.textContent?.trim().replace(/\s+/g, " ") || null;
+				}
+			}
+
+			const containers = document.querySelectorAll(
+				itemsConfig.container_selector,
+			);
+			const results: ExtractionResult[] = [];
+
+			containers.forEach((container) => {
+				const item: Record<string, string | null> = {};
+				const fieldResults: Record<
+					string,
+					{ success: boolean; value: string | null; error?: string }
+				> = {};
+				let hasRequiredFields = true;
+				const missingRequiredFields: string[] = [];
+				const extractionErrors: string[] = [];
+
+				for (const [fieldName, fieldConfig] of Object.entries(
+					itemsConfig.fields,
+				)) {
+					let success = false;
+					let value: string | null = null;
+					let error: string | undefined;
+
+					const typedFieldConfig = fieldConfig as {
+						selector: string;
+						attribute: string;
+						exclude_selectors?: string[];
+						optional?: boolean;
+					};
+
+					try {
+						const element = container.querySelector(typedFieldConfig.selector);
+						if (element) {
+							value = extractFieldValue(element, typedFieldConfig);
+						}
+						success = value !== null && value !== "";
+					} catch (err) {
+						error =
+							err instanceof Error
+								? err.message
+								: `Unknown error extracting field ${fieldName}`;
+						extractionErrors.push(
+							`Field '${fieldName}' extraction failed: ${error}`,
+						);
+					}
+
+					fieldResults[fieldName] = { success, value, error };
+
+					if (success) {
+						item[fieldName] = value;
+					} else if (!typedFieldConfig.optional) {
+						hasRequiredFields = false;
+						missingRequiredFields.push(fieldName);
+					}
+				}
+
+				const hasExcludedUrl = !!excludedUrlPaths.filter((path) =>
+					item.url?.includes(path),
+				).length;
+
+				results.push({
+					item,
+					fieldResults,
+					hasExcludedUrl,
+					hasRequiredFields,
+					missingRequiredFields,
+					extractionErrors,
+				});
+			});
+
+			return results;
+		},
+		config.listing.items,
+		config.content_url_excludes ?? [],
+	);
 
 	const validItems = extractionResult.filter(
 		(result: ExtractionResult) =>
-			result.hasRequiredFields && Object.keys(result.item).length > 0,
+			!result.hasExcludedUrl &&
+			result.hasRequiredFields &&
+			Object.keys(result.item).length > 0,
 	);
 	const filteredItems = extractionResult.filter(
 		(result: ExtractionResult) =>
-			!result.hasRequiredFields || Object.keys(result.item).length === 0,
+			result.hasExcludedUrl ||
+			!result.hasRequiredFields ||
+			Object.keys(result.item).length === 0,
 	);
-
+	extractItemsFromPage;
+	const excludedUrls: string[] = [];
 	const filteredReasons: string[] = [];
 
 	filteredItems.forEach((result: ExtractionResult) => {
+		if (result.hasExcludedUrl && result.item.url) {
+			excludedUrls.push(result.item.url);
+			return;
+		}
 		// Add extraction errors first
 		if (result.extractionErrors.length > 0) {
 			result.extractionErrors.forEach((error) => {
@@ -201,7 +221,7 @@ async function extractItemsFromPage(
 		} else if (!result.hasRequiredFields) {
 			const missingFields = result.missingRequiredFields.join(", ");
 			const itemIdentifier =
-				result.item.title || result.item.url || "Unknown item";
+				result.item.url || result.item.title || "Unknown item";
 			filteredReasons.push(
 				`Item "${itemIdentifier}" missing required fields: ${missingFields}`,
 			);
@@ -210,35 +230,35 @@ async function extractItemsFromPage(
 		}
 	});
 
-	extractionResult.forEach((result: ExtractionResult, itemIndex: number) => {
-		const itemIdentifier =
-			result.item.title || result.item.url || `Item ${itemIndex + 1}`;
+	extractionResult
+		.filter((result) => !result.hasExcludedUrl)
+		.forEach((result: ExtractionResult, itemIndex: number) => {
+			const itemIdentifier =
+				result.item.url || result.item.title || `Item ${itemIndex + 1}`;
 
-		Object.entries(result.fieldResults).forEach(([fieldName, fieldResult]) => {
-			if (!fieldResult.success) {
-				const fieldConfig = config.listing.items.fields[fieldName] as {
-					selector: string;
-					attribute: string;
-					optional?: boolean;
-				};
-				const isOptional = fieldConfig?.optional || false;
+			Object.entries(result.fieldResults).forEach(
+				([fieldName, fieldResult]) => {
+					if (!fieldResult.success) {
+						const fieldConfig = config.listing.items.fields[fieldName] as {
+							selector: string;
+							attribute: string;
+							optional?: boolean;
+						};
+						const isOptional = fieldConfig?.optional || false;
 
-				if (fieldResult.error) {
-					return;
-				}
+						if (fieldResult.error) {
+							return;
+						}
 
-				if (isOptional) {
-					filteredReasons.push(
-						`Optional field '${fieldName}' not found for "${itemIdentifier}"`,
-					);
-				} else {
-					filteredReasons.push(
-						`Required field '${fieldName}' not found for "${itemIdentifier}"`,
-					);
-				}
-			}
+						if (!isOptional) {
+							filteredReasons.push(
+								`Required field '${fieldName}' not found for "${itemIdentifier}". Seen at "${page.url()}"`,
+							);
+						}
+					}
+				},
+			);
 		});
-	});
 
 	extractionResult.forEach((result: ExtractionResult, itemIndex: number) => {
 		fieldStats.forEach((stat) => {
@@ -284,6 +304,7 @@ async function extractItemsFromPage(
 
 	return {
 		items: crawledItems,
+		excludedUrls,
 		filteredCount: filteredItems.length,
 		filteredReasons,
 	};

--- a/src/crawlers/utils/UrlFilter.ts
+++ b/src/crawlers/utils/UrlFilter.ts
@@ -18,48 +18,6 @@ export interface UrlFilterResult {
 }
 
 /**
- * Filter URLs based on exclusion patterns
- */
-export function filterByExclusion(
-	items: CrawledData[],
-	config: UrlFilterConfig,
-	currentOffset: number,
-): UrlFilterResult {
-	if (!config.excludePatterns || config.excludePatterns.length === 0) {
-		return {
-			filteredItems: [...items],
-			excludedCount: 0,
-			excludedItemIndices: [],
-		};
-	}
-
-	const filteredItems: CrawledData[] = [];
-	const excludedItemIndices: number[] = [];
-	let excludedCount = 0;
-
-	items.forEach((item, index) => {
-		const absoluteUrl = new URL(item.url, config.baseUrl).href;
-		const isExcluded = (config.excludePatterns ?? []).some((pattern) =>
-			absoluteUrl.includes(pattern),
-		);
-
-		if (isExcluded) {
-			excludedCount++;
-			// Track the absolute index (offset + current page item index + 1)
-			excludedItemIndices.push(currentOffset + index + 1);
-		} else {
-			filteredItems.push(item);
-		}
-	});
-
-	return {
-		filteredItems,
-		excludedCount,
-		excludedItemIndices,
-	};
-}
-
-/**
  * Filter out duplicate URLs from a set of items
  */
 export function filterDuplicates(

--- a/src/tests/crawlers/MetadataTracker.basic.test.ts
+++ b/src/tests/crawlers/MetadataTracker.basic.test.ts
@@ -231,4 +231,27 @@ describe("MetadataTracker - Basic Functionality", () => {
 		const metadata = metadataTracker.getMetadata();
 		expect(metadata.stoppedReason).toBe("max_pages");
 	});
+
+	it("should track excluded URLs", () => {
+		metadataTracker.addUrlsExcluded(3);
+		metadataTracker.addUrlsExcluded(2);
+
+		const metadata = metadataTracker.getMetadata();
+		expect(metadata.urlsExcluded).toBe(5);
+		// Excluded URLs should also increment totalFilteredItems
+		expect(metadata.totalFilteredItems).toBe(5);
+	});
+
+	it("should track excluded URLs separately from other filtered items", () => {
+		// Add some filtered items
+		metadataTracker.addFilteredItems(2, ["Missing title", "Invalid URL"]);
+
+		// Add some excluded URLs
+		metadataTracker.addUrlsExcluded(3);
+
+		const metadata = metadataTracker.getMetadata();
+		expect(metadata.urlsExcluded).toBe(3);
+		// Total should include both filtered items and excluded URLs
+		expect(metadata.totalFilteredItems).toBe(5);
+	});
 });

--- a/src/tests/crawlers/utils/UrlFilter.test.ts
+++ b/src/tests/crawlers/utils/UrlFilter.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { CrawledData } from "@/core/types.js";
-import {
-	filterByExclusion,
-	filterDuplicates,
-} from "@/crawlers/utils/UrlFilter.js";
+import { filterDuplicates } from "@/crawlers/utils/UrlFilter.js";
 
 describe("UrlFilter", () => {
 	const mockItems: CrawledData[] = [
@@ -32,91 +29,6 @@ describe("UrlFilter", () => {
 			metadata: {},
 		},
 	];
-
-	describe("filterByExclusion", () => {
-		it("should return all items when no exclusion patterns", () => {
-			const result = filterByExclusion(
-				mockItems,
-				{
-					excludePatterns: [],
-					baseUrl: "https://example.com",
-				},
-				0,
-			);
-
-			expect(result.filteredItems).toHaveLength(3);
-			expect(result.excludedCount).toBe(0);
-			expect(result.excludedItemIndices).toEqual([]);
-		});
-
-		it("should return all items when exclusion patterns is undefined", () => {
-			const result = filterByExclusion(
-				mockItems,
-				{
-					baseUrl: "https://example.com",
-				},
-				0,
-			);
-
-			expect(result.filteredItems).toHaveLength(3);
-			expect(result.excludedCount).toBe(0);
-			expect(result.excludedItemIndices).toEqual([]);
-		});
-
-		it("should filter out URLs matching exclusion patterns", () => {
-			const result = filterByExclusion(
-				mockItems,
-				{
-					excludePatterns: ["/excluded/", "/category/"],
-					baseUrl: "https://example.com",
-				},
-				0,
-			);
-
-			expect(result.filteredItems).toHaveLength(1);
-			expect(result.filteredItems[0].url).toBe("https://example.com/article1");
-			expect(result.excludedCount).toBe(2);
-			expect(result.excludedItemIndices).toEqual([2, 3]); // 1-based indices
-		});
-
-		it("should handle relative URLs by converting to absolute", () => {
-			const itemsWithRelativeUrls: CrawledData[] = [
-				{
-					...mockItems[0],
-					url: "/article1",
-				},
-				{
-					...mockItems[1],
-					url: "/excluded/article2",
-				},
-			];
-
-			const result = filterByExclusion(
-				itemsWithRelativeUrls,
-				{
-					excludePatterns: ["/excluded/"],
-					baseUrl: "https://example.com",
-				},
-				0,
-			);
-
-			expect(result.filteredItems).toHaveLength(1);
-			expect(result.excludedCount).toBe(1);
-		});
-
-		it("should use correct offset for excluded item indices", () => {
-			const result = filterByExclusion(
-				mockItems.slice(0, 2), // First two items
-				{
-					excludePatterns: ["/category/"],
-					baseUrl: "https://example.com",
-				},
-				10, // Offset
-			);
-
-			expect(result.excludedItemIndices).toEqual([12]); // offset + index + 1
-		});
-	});
 
 	describe("filterDuplicates", () => {
 		it("should filter out duplicate URLs", () => {

--- a/src/tests/integration/eff-integration.test.ts
+++ b/src/tests/integration/eff-integration.test.ts
@@ -24,15 +24,11 @@ ifDescribe("Electronics Foundation integration tests", () => {
 		const page = await setupPage(browser, config.listing.url);
 		const extractor = createListingPageExtractor();
 		const result = await extractor.extractItemsFromPage(page, config, [], 0);
-		// TODO: Remove when url exclusion is implemented
-		const validItems = result.items.filter(
-			(item) => !item.url.includes("www.eff.org/event/"),
-		);
-		expect(validItems.length).toBeGreaterThan(0);
-		expect(validItems.every((item) => !!item.title)).toBeTruthy();
-		expect(validItems.every((item) => !!item.url)).toBeTruthy();
-		expect(validItems.every((item) => !!item.publishedDate)).toBeTruthy();
-		expect(validItems.every((item) => !!item.content)).toBeTruthy();
+		expect(result.items.length).toBeGreaterThan(0);
+		expect(result.items.every((item) => !!item.title)).toBeTruthy();
+		expect(result.items.every((item) => !!item.url)).toBeTruthy();
+		expect(result.items.every((item) => !!item.publishedDate)).toBeTruthy();
+		expect(result.items.every((item) => !!item.content)).toBeTruthy();
 	});
 
 	it("should crawl to next EFF listing page", async () => {


### PR DESCRIPTION
# Pull Request Review Summary

## Branch: feat/better-url-exclusion
## Comparison: main → feat/better-url-exclusion

### Summary of Changes
This PR introduces significant improvements to URL exclusion functionality by moving the filtering logic from the ArticleListingCrawler to the ListingPageExtractor, where it's executed in the browser context. This change provides more accurate exclusion filtering and better performance.

### Key Changes

1. **URL Filtering Logic Relocation**
   - Removed `filterByExclusion` function from `src/crawlers/utils/UrlFilter.ts`
   - Moved URL exclusion logic to `src/crawlers/extractors/ListingPageExtractor.ts` where it's executed in the browser context
   - Added `excludedUrls` field to `ListingExtractionResult` interface
   - Added `hasExcludedUrl` field to `ExtractionResult` interface

2. **Enhanced Exclusion Implementation**
   - URL exclusion now happens during browser evaluation, preventing excluded URLs from being processed further
   - Excluded URLs are tracked separately and reported in metadata
   - Improved exclusion pattern matching by passing `content_url_excludes` directly to browser evaluation

3. **Updated Source Configuration**
   - Enhanced exclusion patterns for EFF source in `src/config/sources/eff.ts`
   - Changed from simple `"/event/"` pattern to more specific patterns:
     - `"eff.org/event/"`
     - `"eff.org/wp/"`
     - `"eff.org/cases/"`

4. **Simplified ArticleListingCrawler**
   - Removed exclusion filtering logic from `src/crawlers/ArticleListingCrawler.ts`
   - Simplified exclusion tracking to use `pageResult.excludedUrls.length` instead of complex index tracking
   - Removed unused variables related to exclusion filtering

5. **Updated Metadata Tracking**
   - Removed `removeFieldStatsForExcludedUrls` method from `MetadataTracker` as it's no longer needed
   - Simplified exclusion tracking in crawler

6. **Enhanced Testing**
   - Updated tests to reflect new exclusion logic in `src/tests/crawlers/extractors/ListingPageExtractor.test.ts`
   - Removed obsolete exclusion tests from `src/tests/crawlers/utils/UrlFilter.test.ts`
   - Updated integration tests to remove manual exclusion filtering

### Benefits
- **Performance**: Excluded URLs are filtered at the source (browser) rather than after extraction
- **Accuracy**: More precise exclusion based on actual URL patterns
- **Maintainability**: Cleaner separation of concerns with exclusion logic in the right place
- **Traceability**: Better tracking of excluded URLs with dedicated `excludedUrls` field

### Files Modified
- `src/config/sources/eff.ts` - Enhanced exclusion patterns
- `src/crawlers/ArticleListingCrawler.ts` - Removed exclusion filtering logic
- `src/crawlers/MetadataTracker.ts` - Removed obsolete exclusion tracking methods
- `src/crawlers/extractors/ListingPageExtractor.ts` - Moved exclusion logic to browser context
- `src/crawlers/utils/UrlFilter.ts` - Removed `filterByExclusion` function
- Test files updated accordingly