### PR TITLE
refactor(types): use CrawlerType as enum

### DIFF
--- a/src/config/sources/access_now.ts
+++ b/src/config/sources/access_now.ts
@@ -1,14 +1,14 @@
-import type { SourceConfig } from "@/core/types";
+import { CrawlerType, type SourceConfig } from "@/core/types";
 
 export const AccessNowSource: SourceConfig = {
 	id: "access_now",
 	name: "Access Now",
-	type: "listing",
+	type: CrawlerType.Listing,
 	listing: {
 		url: "https://www.accessnow.org/news-updates/?_language=english",
 		pagination: {
 			next_button_selector: ".post-grid-pagination .facetwp-page.next",
-			delaySec: 10, // Access Now blocks IP address when it recognizes a crawling operation
+			delaySec: 10, // Access Now blocks IP address when it detects aggressive crawling
 		},
 		container_selector: ".post-grid.facetwp-template .post-grid-item",
 		shouldExcludeItem: (containerHtml, values) => {

--- a/src/config/sources/declassified_uk.ts
+++ b/src/config/sources/declassified_uk.ts
@@ -1,9 +1,9 @@
-import type { SourceConfig } from "@/core/types";
+import { CrawlerType, type SourceConfig } from "@/core/types";
 
 export const DeclassifiedUkSource: SourceConfig = {
 	id: "declassified_uk",
 	name: "Declassified UK",
-	type: "listing",
+	type: CrawlerType.Listing,
 	disableJavascript: true,
 	listing: {
 		url: "https://www.declassifieduk.org/category/archive/",

--- a/src/config/sources/electronic_frontier_foundation.ts
+++ b/src/config/sources/electronic_frontier_foundation.ts
@@ -1,9 +1,9 @@
-import type { SourceConfig } from "@/core/types";
+import { CrawlerType, type SourceConfig } from "@/core/types";
 
 export const ElectronicFrontierFoundationSource: SourceConfig = {
 	id: "electronic_frontier_foundation",
 	name: "Electronic Frontier Foundation",
-	type: "listing",
+	type: CrawlerType.Listing,
 	listing: {
 		url: "https://eff.org/updates",
 		pagination: {

--- a/src/config/sources/freedom_press_foundation.ts
+++ b/src/config/sources/freedom_press_foundation.ts
@@ -1,9 +1,9 @@
-import type { SourceConfig } from "@/core/types";
+import { CrawlerType, type SourceConfig } from "@/core/types";
 
 export const FreedomPressFoundationSource: SourceConfig = {
 	id: "freedom_press_foundation",
 	name: "Freedom of the Press Foundation",
-	type: "listing",
+	type: CrawlerType.Listing,
 	listing: {
 		url: "https://freedom.press/issues/",
 		pagination: {

--- a/src/config/sources/logos_press_engine.ts
+++ b/src/config/sources/logos_press_engine.ts
@@ -1,9 +1,9 @@
-import type { SourceConfig } from "@/core/types";
+import { CrawlerType, type SourceConfig } from "@/core/types";
 
 export const LogosPressEngineSource: SourceConfig = {
 	id: "logos_press_engine",
 	name: "Logos Press Engine",
-	type: "listing",
+	type: CrawlerType.Listing,
 	listing: {
 		url: "https://press.logos.co/search?type=article",
 		pagination: {

--- a/src/config/sources/p2p_foundation.ts
+++ b/src/config/sources/p2p_foundation.ts
@@ -1,9 +1,9 @@
-import type { SourceConfig } from "@/core/types";
+import { CrawlerType, type SourceConfig } from "@/core/types";
 
 export const P2pFoundationSource: SourceConfig = {
 	id: "p2p_foundation",
 	name: "P2P Foundation",
-	type: "listing",
+	type: CrawlerType.Listing,
 	disableJavascript: true,
 	listing: {
 		url: "https://blog.p2pfoundation.net/",

--- a/src/config/sources/torrent_freak.ts
+++ b/src/config/sources/torrent_freak.ts
@@ -1,9 +1,9 @@
-import type { SourceConfig } from "@/core/types";
+import { CrawlerType, type SourceConfig } from "@/core/types";
 
 export const TorrentFreakSource: SourceConfig = {
 	id: "torrent_freak",
 	name: "TorrentFreak",
-	type: "listing",
+	type: CrawlerType.Listing,
 	listing: {
 		url: "https://torrentfreak.com/",
 		pagination: {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -8,11 +8,9 @@ import type {
 } from "@/crawlers/extractors/ListingPageExtractor";
 import type { StoppedReason } from "@/crawlers/MetadataTracker";
 
-export const CRAWLER_TYPES = {
-	LISTING: "listing",
-} as const;
-
-export type CrawlerType = (typeof CRAWLER_TYPES)[keyof typeof CRAWLER_TYPES];
+export enum CrawlerType {
+	Listing = "listing",
+}
 
 // Core crawler interfaces
 export interface Crawler {

--- a/src/crawlers/ArticleListingCrawler.ts
+++ b/src/crawlers/ArticleListingCrawler.ts
@@ -6,7 +6,7 @@ import type {
 	CrawlResult,
 	SourceConfig,
 } from "@/core/types.js";
-import { CRAWLER_TYPES, CrawlerError } from "@/core/types.js";
+import { CrawlerError, CrawlerType } from "@/core/types.js";
 import { createContentPageExtractor } from "@/crawlers/extractors/ContentPageExtractor";
 import type { ContentPageExtractor } from "@/crawlers/extractors/ContentPageExtractor.js";
 import { EXTRACTION_CONCURRENCY } from "@/crawlers/extractors/constants";
@@ -199,9 +199,9 @@ async function crawlListing(
 
 	interruptionHandler.setup();
 
-	if (config.type !== CRAWLER_TYPES.LISTING) {
+	if (config.type !== CrawlerType.Listing) {
 		throw new CrawlerError(
-			`Config type must be '${CRAWLER_TYPES.LISTING}' (only supported type in Phase 1)`,
+			`Config type must be '${CrawlerType.Listing}' (only supported type in Phase 1)`,
 			config.id,
 		);
 	}
@@ -344,7 +344,7 @@ async function extractItemsFromListing(
 
 export function createArticleListingCrawler(): Crawler {
 	return {
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		crawl: crawlListing,
 	};
 }

--- a/src/crawlers/extractors/ListingPageExtractor.ts
+++ b/src/crawlers/extractors/ListingPageExtractor.ts
@@ -1,12 +1,12 @@
 import type { Page } from "puppeteer";
-import type {
-	CrawledData,
-	FieldConfig,
-	FieldExtractionStats,
-	ListingConfig,
-	SourceConfig,
+import {
+	type CrawledData,
+	CrawlerType,
+	type FieldConfig,
+	type FieldExtractionStats,
+	type ListingConfig,
+	type SourceConfig,
 } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
 import { DYNAMIC_CONTENT_TIMEOUT } from "@/crawlers/extractors/constants";
 import { parsePublishedDate } from "@/utils/date.js";
 import type { ContentFieldName } from "./ContentPageExtractor";
@@ -331,7 +331,7 @@ async function extractItemsFromPage(
 				author: result.values.author || undefined,
 				publishedDate,
 				metadata: {
-					crawlerType: CRAWLER_TYPES.LISTING,
+					crawlerType: CrawlerType.Listing,
 					configId: config.id,
 					extractedFields: Object.keys(result.values),
 				},

--- a/src/tests/core/ProcessingPipeline.basic.test.ts
+++ b/src/tests/core/ProcessingPipeline.basic.test.ts
@@ -8,7 +8,7 @@ import type {
 	CrawlResult,
 	SourceConfig,
 } from "@/core/types.js";
-import { CRAWLER_TYPES, CrawlerError } from "@/core/types.js";
+import { CrawlerError, CrawlerType } from "@/core/types.js";
 
 describe("ProcessingPipeline - Basic Functionality", () => {
 	beforeEach(async () => {
@@ -32,14 +32,12 @@ describe("ProcessingPipeline - Basic Functionality", () => {
 	const testConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		listing: {
 			url: "https://example.com",
-			items: {
-				container_selector: "article",
-				fields: {
-					title: { selector: "h1", attribute: "text" },
-				},
+			container_selector: "article",
+			fields: {
+				title: { selector: "h1", attribute: "text" },
 			},
 		},
 		content: {
@@ -60,13 +58,13 @@ describe("ProcessingPipeline - Basic Functionality", () => {
 
 		await expect(pipeline.process(testConfig)).rejects.toThrow(CrawlerError);
 		await expect(pipeline.process(testConfig)).rejects.toThrow(
-			`No crawler found for type: ${CRAWLER_TYPES.LISTING}`,
+			`No crawler found for type: ${CrawlerType.Listing}`,
 		);
 	});
 
 	it("should process successful crawl results", async () => {
 		const mockCrawler: Crawler = {
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			async crawl(
 				_config: SourceConfig,
 				options?: CrawlOptions,
@@ -129,7 +127,7 @@ describe("ProcessingPipeline - Basic Functionality", () => {
 
 	it("should handle crawler errors", async () => {
 		const failingCrawler: Crawler = {
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			async crawl(): Promise<CrawlResult> {
 				throw new Error("Network failure");
 			},

--- a/src/tests/core/ProcessingPipeline.options.test.ts
+++ b/src/tests/core/ProcessingPipeline.options.test.ts
@@ -8,7 +8,7 @@ import type {
 	CrawlResult,
 	SourceConfig,
 } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 
 describe("ProcessingPipeline - Options and Configuration", () => {
 	beforeEach(async () => {
@@ -32,14 +32,12 @@ describe("ProcessingPipeline - Options and Configuration", () => {
 	const testConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		listing: {
 			url: "https://example.com",
-			items: {
-				container_selector: "article",
-				fields: {
-					title: { selector: "h1", attribute: "text" },
-				},
+			container_selector: "article",
+			fields: {
+				title: { selector: "h1", attribute: "text" },
 			},
 		},
 		content: {
@@ -54,7 +52,7 @@ describe("ProcessingPipeline - Options and Configuration", () => {
 		let receivedOptions: CrawlOptions | undefined;
 
 		const mockCrawler: Crawler = {
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			async crawl(
 				config: SourceConfig,
 				options?: CrawlOptions,
@@ -99,7 +97,7 @@ describe("ProcessingPipeline - Options and Configuration", () => {
 		let receivedOptions: CrawlOptions | undefined;
 
 		const mockCrawler: Crawler = {
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			async crawl(
 				config: SourceConfig,
 				options?: CrawlOptions,

--- a/src/tests/crawlers/ArticleListingCrawler.basic.test.ts
+++ b/src/tests/crawlers/ArticleListingCrawler.basic.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { CRAWLER_TYPES, type SourceConfig } from "@/core/types.js";
+import { CrawlerType, type SourceConfig } from "@/core/types.js";
 import { createArticleListingCrawler } from "@/crawlers/ArticleListingCrawler.js";
 
 // Mock the BrowserHandler to prevent Puppeteer from being called
@@ -17,7 +17,7 @@ vi.mock("@/crawlers/handlers/BrowserHandler.js", () => {
 describe("ArticleListingCrawler - Basic Functionality", () => {
 	it("should have correct type", () => {
 		const crawler = createArticleListingCrawler();
-		expect(crawler.type).toBe(CRAWLER_TYPES.LISTING);
+		expect(crawler.type).toBe(CrawlerType.Listing);
 	});
 
 	it("should reject non-listing config types", async () => {

--- a/src/tests/crawlers/ArticleListingCrawler.config.test.ts
+++ b/src/tests/crawlers/ArticleListingCrawler.config.test.ts
@@ -1,24 +1,22 @@
 import { describe, expect, it } from "vitest";
 import type { SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 
 describe("ArticleListingCrawler - Configuration Validation", () => {
 	it("should handle pagination config structure", () => {
 		const configWithPagination: SourceConfig = {
 			id: "test-pagination",
 			name: "Test Pagination",
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			listing: {
 				url: "https://example.com",
 				pagination: {
 					next_button_selector: ".pager__item.pager__item--next",
 					// Add more pagination config as needed
 				},
-				items: {
-					container_selector: ".item",
-					fields: {
-						title: { selector: ".title", attribute: "text" },
-					},
+				container_selector: ".item",
+				fields: {
+					title: { selector: ".title", attribute: "text" },
 				},
 			},
 			content: {
@@ -38,14 +36,12 @@ describe("ArticleListingCrawler - Configuration Validation", () => {
 		const configNoPagination: SourceConfig = {
 			id: "test-no-pagination",
 			name: "Test No Pagination",
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			listing: {
 				url: "https://example.com",
-				items: {
-					container_selector: ".item",
-					fields: {
-						title: { selector: ".title", attribute: "text" },
-					},
+				container_selector: ".item",
+				fields: {
+					title: { selector: ".title", attribute: "text" },
 				},
 			},
 			content: {
@@ -63,15 +59,13 @@ describe("ArticleListingCrawler - Configuration Validation", () => {
 		const configWithContent: SourceConfig = {
 			id: "test-content",
 			name: "Test Content",
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			listing: {
 				url: "https://example.com",
-				items: {
-					container_selector: ".item",
-					fields: {
-						url: { selector: "a", attribute: "href" },
-						title: { selector: ".title", attribute: "text" },
-					},
+				container_selector: ".item",
+				fields: {
+					url: { selector: "a", attribute: "href" },
+					title: { selector: ".title", attribute: "text" },
 				},
 			},
 			content: {
@@ -85,8 +79,8 @@ describe("ArticleListingCrawler - Configuration Validation", () => {
 		};
 
 		expect(configWithContent.content).toBeDefined();
-		expect(configWithContent.content?.fields.title.selector).toBe("h1");
-		expect(configWithContent.content?.fields.author.optional).toBe(true);
+		expect(configWithContent.content?.fields.title?.selector).toBe("h1");
+		expect(configWithContent.content?.fields.author?.optional).toBe(true);
 	});
 
 	it("should validate field configurations", () => {

--- a/src/tests/crawlers/MetadataTracker.basic.test.ts
+++ b/src/tests/crawlers/MetadataTracker.basic.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import {
 	createMetadataTracker,
 	StoppedReason,
@@ -49,7 +49,7 @@ describe("MetadataTracker - Basic Functionality", () => {
 		mockConfig = {
 			id: "test-source",
 			name: "Test Source",
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			listing: {
 				url: "https://example.com",
 				container_selector: ".item",

--- a/src/tests/crawlers/MetadataTracker.items.test.ts
+++ b/src/tests/crawlers/MetadataTracker.items.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CrawledData, SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { createMetadataTracker } from "@/crawlers/MetadataTracker.js";
 import type { MetadataStore } from "@/storage/MetadataStore.js";
 
@@ -46,7 +46,7 @@ describe("MetadataTracker - Items Processing", () => {
 		mockConfig = {
 			id: "test-source",
 			name: "Test Source",
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			listing: {
 				url: "https://example.com",
 				container_selector: ".item",

--- a/src/tests/crawlers/MetadataTracker.return-value.test.ts
+++ b/src/tests/crawlers/MetadataTracker.return-value.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import {
 	createMetadataTracker,
 	StoppedReason,
@@ -49,7 +49,7 @@ describe("MetadataTracker - Return Values", () => {
 		mockConfig = {
 			id: "test-source",
 			name: "Test Source",
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			listing: {
 				url: "https://example.com",
 				container_selector: ".item",

--- a/src/tests/crawlers/MetadataTracker.session.test.ts
+++ b/src/tests/crawlers/MetadataTracker.session.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CrawledData, SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import {
 	createMetadataTracker,
 	StoppedReason,
@@ -49,7 +49,7 @@ describe("MetadataTracker - Session Management", () => {
 		mockConfig = {
 			id: "test-source",
 			name: "Test Source",
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			listing: {
 				url: "https://example.com",
 				container_selector: ".item",

--- a/src/tests/crawlers/extractors/ConcurrentContentExtractor.test.ts
+++ b/src/tests/crawlers/extractors/ConcurrentContentExtractor.test.ts
@@ -5,7 +5,7 @@ import type {
 	FieldExtractionStats,
 	SourceConfig,
 } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { createConcurrentContentExtractor } from "@/crawlers/extractors/ConcurrentContentExtractor.js";
 import type { BrowserHandler } from "@/crawlers/handlers/BrowserHandler.js";
 import type { MetadataStore } from "@/storage/MetadataStore.js";
@@ -20,7 +20,7 @@ describe("ConcurrentContentExtractor", () => {
 	const mockConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		listing: {
 			url: "https://example.com",
 			container_selector: ".article",

--- a/src/tests/crawlers/extractors/ContentPageExtractor.test.ts
+++ b/src/tests/crawlers/extractors/ContentPageExtractor.test.ts
@@ -5,7 +5,7 @@ import type {
 	FieldExtractionStats,
 	SourceConfig,
 } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { createContentPageExtractor } from "@/crawlers/extractors/ContentPageExtractor";
 import type { BrowserHandler } from "@/crawlers/handlers/BrowserHandler";
 
@@ -44,7 +44,7 @@ describe("ContentPageExtractor", () => {
 		mockConfig = {
 			id: "test",
 			name: "Test Source",
-			type: CRAWLER_TYPES.LISTING,
+			type: CrawlerType.Listing,
 			listing: {
 				url: "https://example.com",
 				container_selector: ".article",

--- a/src/tests/crawlers/extractors/ListingPageExtractor.test.ts
+++ b/src/tests/crawlers/extractors/ListingPageExtractor.test.ts
@@ -1,14 +1,14 @@
 import type { Page } from "puppeteer";
 import { describe, expect, it, vi } from "vitest";
 import type { FieldExtractionStats, SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { createListingPageExtractor } from "@/crawlers/extractors/ListingPageExtractor.js";
 
 describe("ListingPageExtractor", () => {
 	const mockConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		listing: {
 			url: "https://example.com",
 			container_selector: ".article",

--- a/src/tests/crawlers/extractors/ListingPageExtractor.whitespace.test.ts
+++ b/src/tests/crawlers/extractors/ListingPageExtractor.whitespace.test.ts
@@ -1,14 +1,14 @@
 import type { Page } from "puppeteer";
 import { describe, expect, it, vi } from "vitest";
 import type { FieldExtractionStats, SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { createListingPageExtractor } from "@/crawlers/extractors/ListingPageExtractor.js";
 
 describe("ListingPageExtractor - Whitespace handling", () => {
 	const mockConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		listing: {
 			url: "https://example.com",
 			container_selector: ".article",

--- a/src/tests/crawlers/handlers/BrowserHandler.test.ts
+++ b/src/tests/crawlers/handlers/BrowserHandler.test.ts
@@ -1,7 +1,7 @@
 import type { Browser, Page } from "puppeteer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { createBrowserHandler } from "@/crawlers/handlers/BrowserHandler.js";
 import * as urlUtils from "@/utils/url.js";
 
@@ -34,15 +34,13 @@ describe("BrowserHandler", () => {
 	const mockConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		disableJavascript: false,
 		listing: {
 			url: "https://example.com",
-			items: {
-				container_selector: ".article",
-				fields: {
-					title: { selector: ".title", attribute: "text" },
-				},
+			container_selector: ".article",
+			fields: {
+				title: { selector: ".title", attribute: "text" },
 			},
 		},
 		content: {

--- a/src/tests/crawlers/handlers/PaginationHandler.buttons.test.ts
+++ b/src/tests/crawlers/handlers/PaginationHandler.buttons.test.ts
@@ -1,7 +1,7 @@
 import type { Page } from "puppeteer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { navigateToNextPage } from "@/crawlers/handlers/PaginationHandler.js";
 
 describe("PaginationHandler - Button Detection", () => {
@@ -17,14 +17,12 @@ describe("PaginationHandler - Button Detection", () => {
 	const mockConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		listing: {
 			url: "https://example.com",
-			items: {
-				container_selector: ".article",
-				fields: {
-					title: { selector: ".title", attribute: "text" },
-				},
+			container_selector: ".article",
+			fields: {
+				title: { selector: ".title", attribute: "text" },
 			},
 			pagination: {
 				next_button_selector: ".next-page",

--- a/src/tests/crawlers/handlers/PaginationHandler.errors.test.ts
+++ b/src/tests/crawlers/handlers/PaginationHandler.errors.test.ts
@@ -1,7 +1,7 @@
 import type { Page } from "puppeteer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { navigateToNextPage } from "@/crawlers/handlers/PaginationHandler.js";
 
 describe("PaginationHandler - Error Handling", () => {
@@ -17,14 +17,12 @@ describe("PaginationHandler - Error Handling", () => {
 	const mockConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		listing: {
 			url: "https://example.com",
-			items: {
-				container_selector: ".article",
-				fields: {
-					title: { selector: ".title", attribute: "text" },
-				},
+			container_selector: ".article",
+			fields: {
+				title: { selector: ".title", attribute: "text" },
 			},
 			pagination: {
 				next_button_selector: ".next-page",

--- a/src/tests/crawlers/handlers/PaginationHandler.navigation.test.ts
+++ b/src/tests/crawlers/handlers/PaginationHandler.navigation.test.ts
@@ -1,7 +1,7 @@
 import type { Page } from "puppeteer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { navigateToNextPage } from "@/crawlers/handlers/PaginationHandler.js";
 
 describe("PaginationHandler - Navigation", () => {
@@ -17,7 +17,7 @@ describe("PaginationHandler - Navigation", () => {
 	const mockConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		listing: {
 			url: "https://example.com",
 			container_selector: ".article",

--- a/src/tests/crawlers/handlers/PaginationHandler.retry.test.ts
+++ b/src/tests/crawlers/handlers/PaginationHandler.retry.test.ts
@@ -1,7 +1,7 @@
 import type { Page } from "puppeteer";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SourceConfig } from "@/core/types.js";
-import { CRAWLER_TYPES } from "@/core/types.js";
+import { CrawlerType } from "@/core/types.js";
 import { navigateToNextPage } from "@/crawlers/handlers/PaginationHandler.js";
 
 describe("PaginationHandler - Retry Logic", () => {
@@ -17,14 +17,12 @@ describe("PaginationHandler - Retry Logic", () => {
 	const mockConfig: SourceConfig = {
 		id: "test",
 		name: "Test Source",
-		type: CRAWLER_TYPES.LISTING,
+		type: CrawlerType.Listing,
 		listing: {
 			url: "https://example.com",
-			items: {
-				container_selector: ".article",
-				fields: {
-					title: { selector: ".title", attribute: "text" },
-				},
+			container_selector: ".article",
+			fields: {
+				title: { selector: ".title", attribute: "text" },
 			},
 			pagination: {
 				next_button_selector: ".next-page",


### PR DESCRIPTION
# Pull Request: Refactor Crawler Type Implementation

## Summary of Changes
This PR refactors the crawler type implementation to use a TypeScript enum (CrawlerType) instead of string literals. This change improves type safety and maintainability across the codebase.

## Key Changes

### 1. Type Safety Enhancement
- Replaced string-based crawler types ("listing") with CrawlerType enum
- Updated import statements to include CrawlerType from core types

### 2. Configuration Structure Updates
- Simplified source configuration structure by removing the nested items object
- Moved container_selector and fields properties directly under listing

### 3. Core Type Definitions
- Updated core/types.ts to use the new CrawlerType enum
- Removed CRAWLER_TYPES constant in favor of the enum

### 4. Comprehensive Test Updates
- Updated all test files to use the new CrawlerType enum
- Modified test configurations to match the new structure
- Fixed optional chaining in content field assertions