### PR TITLE
refactor: rename date extraction field to publishedDate

### DIFF
--- a/src/config/sources/access_now.ts
+++ b/src/config/sources/access_now.ts
@@ -30,7 +30,7 @@ export const AccessNowSource: SourceConfig = {
 				selector: ".post-grid-item--link",
 				attribute: "href",
 			},
-			date: {
+			publishedDate: {
 				selector: ".post-grid-item--date",
 				attribute: "text",
 			},

--- a/src/config/sources/declassified_uk.ts
+++ b/src/config/sources/declassified_uk.ts
@@ -20,7 +20,7 @@ export const DeclassifiedUkSource: SourceConfig = {
 				selector: ".entry-title a",
 				attribute: "href",
 			},
-			date: {
+			publishedDate: {
 				selector: ".post-meta .published",
 				attribute: "text",
 			},

--- a/src/config/sources/electronic_frontier_foundation.ts
+++ b/src/config/sources/electronic_frontier_foundation.ts
@@ -29,7 +29,7 @@ export const ElectronicFrontierFoundationSource: SourceConfig = {
 				selector: ".node__title a",
 				attribute: "href",
 			},
-			date: {
+			publishedDate: {
 				selector: ".node-date",
 				attribute: "text",
 			},

--- a/src/config/sources/freedom_press_foundation.ts
+++ b/src/config/sources/freedom_press_foundation.ts
@@ -19,7 +19,7 @@ export const FreedomPressFoundationSource: SourceConfig = {
 				selector: ".heading .card-link",
 				attribute: "href",
 			},
-			date: {
+			publishedDate: {
 				selector: ".meta-info time",
 				attribute: "datetime",
 			},

--- a/src/config/sources/logos_press_engine.ts
+++ b/src/config/sources/logos_press_engine.ts
@@ -19,7 +19,7 @@ export const LogosPressEngineSource: SourceConfig = {
 				selector: ".post-card__title",
 				attribute: "href",
 			},
-			date: {
+			publishedDate: {
 				selector: ".post-card__label span:nth-of-type(2)",
 				attribute: "text",
 			},

--- a/src/config/sources/p2p_foundation.ts
+++ b/src/config/sources/p2p_foundation.ts
@@ -20,7 +20,7 @@ export const P2pFoundationSource: SourceConfig = {
 				selector: ".entry-title a",
 				attribute: "href",
 			},
-			date: {
+			publishedDate: {
 				selector: ".entry-date",
 				attribute: "text",
 			},

--- a/src/config/sources/torrent_freak.ts
+++ b/src/config/sources/torrent_freak.ts
@@ -19,7 +19,7 @@ export const TorrentFreakSource: SourceConfig = {
 				selector: "& > a",
 				attribute: "href",
 			},
-			date: {
+			publishedDate: {
 				selector: ".preview-article__published time",
 				attribute: "text",
 			},

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,7 +1,4 @@
-import type {
-	ContentFieldName,
-	ExtractedContentValues,
-} from "@/crawlers/extractors/ContentPageExtractor";
+import type { ContentFieldName } from "@/crawlers/extractors/ContentPageExtractor";
 import type {
 	ExtractedListingValues,
 	ListingFieldName,

--- a/src/crawlers/extractors/ContentDataMapper.ts
+++ b/src/crawlers/extractors/ContentDataMapper.ts
@@ -13,9 +13,9 @@ export function mergeContentData(
 	if (contentData.content) item.content = contentData.content;
 	if (contentData.author) item.author = contentData.author;
 
-	if (contentData.date) {
+	if (contentData.publishedDate) {
 		try {
-			const parsedDate = parsePublishedDate(contentData.date);
+			const parsedDate = parsePublishedDate(contentData.publishedDate);
 			item.publishedDate = parsedDate;
 		} catch (error) {
 			throw new Error(

--- a/src/crawlers/extractors/ContentPageExtractor.ts
+++ b/src/crawlers/extractors/ContentPageExtractor.ts
@@ -61,7 +61,7 @@ export interface ContentExtractionData {
 	title?: string;
 	content?: string;
 	author?: string;
-	date?: string;
+	publishedDate?: string;
 }
 
 export interface ContentExtractionResult {

--- a/src/crawlers/extractors/ListingPageExtractor.ts
+++ b/src/crawlers/extractors/ListingPageExtractor.ts
@@ -21,7 +21,7 @@ export interface ListingExtractionResult {
 export interface ExtractedListingValues {
 	title: string | null;
 	url: string | null;
-	date: string | null;
+	publishedDate: string | null;
 	author: string | null;
 }
 export type ListingFieldName = keyof ExtractedListingValues;
@@ -141,7 +141,7 @@ async function extractItemsFromPage(
 					const extractedValues: ExtractedListingValues = {
 						title: null,
 						url: null,
-						date: null,
+						publishedDate: null,
 						author: null,
 					};
 					const fieldResults: Record<
@@ -313,8 +313,8 @@ async function extractItemsFromPage(
 		(result: ExtractionResult) => {
 			let publishedDate: string | undefined;
 			try {
-				publishedDate = result.values.date
-					? parsePublishedDate(result.values.date)
+				publishedDate = result.values.publishedDate
+					? parsePublishedDate(result.values.publishedDate)
 					: undefined;
 			} catch (error) {
 				throw new Error(

--- a/src/tests/crawlers/extractors/ContentDataMapper.test.ts
+++ b/src/tests/crawlers/extractors/ContentDataMapper.test.ts
@@ -28,7 +28,7 @@ describe("ContentDataMapper", () => {
 				title: "Full Title",
 				content: "Full content",
 				author: "John Doe",
-				date: "2023-01-01",
+				publishedDate: "2023-01-01",
 			};
 
 			mergeContentData(item, contentData);
@@ -55,7 +55,7 @@ describe("ContentDataMapper", () => {
 				title: "Full Title",
 				// content is missing
 				// author is missing
-				date: "2023-01-01",
+				publishedDate: "2023-01-01",
 			};
 
 			mergeContentData(item, contentData);
@@ -126,7 +126,7 @@ describe("ContentDataMapper", () => {
 			};
 
 			const contentData = {
-				date: "invalid-date",
+				publishedDate: "invalid-date",
 			};
 
 			expect(() => mergeContentData(item, contentData)).toThrow(


### PR DESCRIPTION
# Pull Request Summary

## Branch Comparison
- **Source Branch**: `refactor/rename_date_extraction_field_to_published-date`
- **Target Branch**: `main`
- **Commit**: bf45a59 - "refactor: rename date extraction field to publishedDate"

## Changes Overview
This PR implements a refactor to rename the date extraction field from `date` to `publishedDate` across the codebase for improved clarity and consistency.